### PR TITLE
Erreur GuzzleHttp lorsqu'un objet n'existe pas #16

### DIFF
--- a/src/Sitra/ApiClient/Exception/SitraException.php
+++ b/src/Sitra/ApiClient/Exception/SitraException.php
@@ -3,14 +3,14 @@
 namespace Sitra\ApiClient\Exception;
 
 use Exception;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\GuzzleException;
 
 class SitraException extends \Exception
 {
     protected $request;
     protected $response;
 
-    public function __construct(RequestException $e)
+    public function __construct(GuzzleException $e)
     {
         $this->request  = $e->getRequest();
         $this->response = $e->getResponse();
@@ -30,8 +30,8 @@ class SitraException extends \Exception
             $code = $this->response->getStatusCode();
         }
 
-        $responseDescription = $this->response ? (string) $this->response : 'none';
-        $requestDescription = $this->request ? (string) $this->request : 'none';
+        $responseDescription = $this->response ? (string) $this->response->getBody()->getContents() : 'none';
+        $requestDescription = $this->request ? (string) $this->request->getBody()->getContents() : 'none';
 
         $message = sprintf("%s
 


### PR DESCRIPTION
SitraException __construct doit être en mesure d'accueillir dans son constructeur des exceptions de la forme :
* CommandClientException
* CommandServerException
* CommandException
* RequestException

Ces dernières sont toutes dérivées de GuzzleException, utiliser cette classe dans le constructeur solutionne le problème suivant : 

> Type error: Argument 1 passed to Sitra\ApiClient\Exception\SitraException::__construct() must be an instance of GuzzleHttp\Exception\RequestException, instance of GuzzleHttp\Command\Exception\CommandClientException given, called in /var/www/cabacms-2-dev/vendor/sitra-tourisme/sitra-api-php/src/Sitra/ApiClient/Client.php on line 289

Toutefois, ces Exceptions ne peuvent pas être castées en (string) directement ainsi je propose d'ajouter "->getBody()->getContents()" pour obtenir une chaîne de caractères comme attendu initialement.

See: https://github.com/apidae-tourisme/sitra-api-php/issues/16